### PR TITLE
r1.sh: `set -euo pipefail`

### DIFF
--- a/r1.sh
+++ b/r1.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 install_debian() {
     sudo apt update
     [[ -x "$(command -v git)" ]] || sudo apt install -y git


### PR DESCRIPTION
I'm seeing a few people having issues resulting in the script continuing after an error, where it probably shouldn't. For example, #59. This should [fix that](https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425).

NOTE: This change is entirely untested!